### PR TITLE
Attempt to fix code glow on safari

### DIFF
--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -32,6 +32,9 @@ const Pre = styled.pre`
   hyphens: none;
   padding: 4 0;
 
+  -webkit-appearance: none;
+  -webkit-box-shadow: rgba(34, 211, 238, 0.20) 0px 0px 200px;
+  -moz-box-shadow: rgba(34, 211, 238, 0.20) 0px 0px 200px;
   box-shadow: rgba(34, 211, 238, 0.20) 0px 0px 200px;
 
   textarea {


### PR DESCRIPTION
e.g.:
```css
-webkit-box-shadow: 1px 1px 0px rgba(0,0,0,0.1);/*For webkit browsers*/
-moz-box-shadow: 1px 1px 0px rgba(0,0,0,0.1);/*For Firefox*/
box-shadow: 1px 1px 0px rgba(0,0,0,0.1)
```